### PR TITLE
Console script entry + version from package metadata

### DIFF
--- a/impsy/web_interface.py
+++ b/impsy/web_interface.py
@@ -7,6 +7,7 @@ import platform
 import os
 import time
 import tomllib
+from importlib.metadata import PackageNotFoundError, metadata as _pkg_metadata, version as _pkg_version
 from threading import Lock, Thread
 from impsy.dataset import generate_dataset
 from pathlib import Path
@@ -32,12 +33,10 @@ _pause_state = False
 
 
 def get_version():
-    """Get project version from pyproject.toml."""
+    """Get the installed impsy package version."""
     try:
-        with open("pyproject.toml", "rb") as f:
-            data = tomllib.load(f)
-        return data.get("project", {}).get("version", "")
-    except Exception:
+        return _pkg_version("impsy")
+    except PackageNotFoundError:
         return ""
 
 
@@ -215,19 +214,25 @@ def get_hardware_info():
 
 
 def get_software_info():
-    with open("pyproject.toml", "rb") as f:
-        pyproject_data = tomllib.load(f)
-    project = pyproject_data.get("project", {})
-    urls = project.get("urls", {})
-    authors = project.get("authors", [])
-    author_names = [a.get("name", "") for a in authors if isinstance(a, dict)]
+    """Return human-readable project metadata from the installed package."""
+    try:
+        meta = _pkg_metadata("impsy")
+    except PackageNotFoundError:
+        return {}
+    project_urls = {}
+    for entry in meta.get_all("Project-URL") or []:
+        label, _, url = entry.partition(",")
+        if url:
+            project_urls[label.strip().lower()] = url.strip()
+    authors = meta.get("Author") or ""
+    author_names = [a.strip() for a in authors.split(",") if a.strip()]
     return {
-        "Project": project.get("name"),
-        "Version": project.get("version"),
-        "Description": project.get("description"),
+        "Project": meta["Name"],
+        "Version": meta["Version"],
+        "Description": meta["Summary"],
         "Authors": author_names if author_names else None,
-        "Homepage": urls.get("homepage"),
-        "Repository": urls.get("repository"),
+        "Homepage": project_urls.get("homepage"),
+        "Repository": project_urls.get("repository"),
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 homepage = "https://charlesmartin.au/impsy-homepage/"
 repository = "https://github.com/cpmpercussion/impsy"
 
+[project.scripts]
+impsy = "impsy.impsy:main"
+
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0.3,<10"
 flake8 = ">=7.0.0,<8"

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -9,6 +9,8 @@ from impsy.web_interface import (
     allowed_model_file,
     allowed_log_file,
     allowed_dataset_file,
+    get_version,
+    get_software_info,
 )
 
 
@@ -24,6 +26,34 @@ def test_index_route(client):
     assert response.status_code == 200
     assert b"IMPSY" in response.data
     assert b"Dashboard" in response.data
+
+
+def test_get_version_reads_package_metadata():
+    """get_version returns the installed package version, independent of CWD."""
+    v = get_version()
+    assert v, "expected a non-empty version string from importlib.metadata"
+    # Version follows PEP 440 prefix conventions; we just check it has digits/dots.
+    assert any(ch.isdigit() for ch in v)
+
+
+def test_get_software_info_reads_package_metadata():
+    """get_software_info pulls Name/Version/Summary/Authors/URLs from metadata."""
+    info = get_software_info()
+    assert info["Project"] == "impsy"
+    assert info["Version"] == get_version()
+    assert info["Description"]
+    assert info["Authors"]
+    assert info["Homepage"]
+    assert info["Repository"]
+
+
+def test_get_version_independent_of_cwd(tmp_path, monkeypatch):
+    """The version lookup must not depend on a pyproject.toml in CWD."""
+    monkeypatch.chdir(tmp_path)
+    assert not (tmp_path / "pyproject.toml").exists()
+    assert get_version()  # still resolves from installed metadata
+    info = get_software_info()
+    assert info.get("Project") == "impsy"
 
 
 def test_logs_route(client):


### PR DESCRIPTION
## Summary

- Adds `[project.scripts] impsy = "impsy.impsy:main"` so `pip install impsy` now drops an `impsy` executable onto PATH. `start_impsy.py` continues to work for source-tree clones; both routes call the same `main()`.
- Switches `get_version()` and `get_software_info()` in `impsy/web_interface.py` to read from `importlib.metadata`. Previously both opened `pyproject.toml` from CWD, which only worked when running from the source tree — pip users were getting silent empty strings in the webui.
- Adds three tests covering the metadata reads and verifying they're independent of CWD.

Closes #80. Part of the broader "make pip install impsy && impsy run actually work" effort (#81 workspace paths, #82 init scaffolding, #83 README quickstart).

## Test plan

- [x] `poetry run pytest` — 144 passed locally (141 + 3 new)
- [x] `poetry run impsy --help` lists all six subcommands
- [x] `poetry run impsy run --help` shows the v1.1.0 override flags
- [x] `get_version()` / `get_software_info()` return 1.1.0 from a `tmp_path` directory with no pyproject.toml
- [ ] Full CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)