### PR TITLE
Workspace-relative webui paths + bundled default template

### DIFF
--- a/impsy/data/default.toml
+++ b/impsy/data/default.toml
@@ -1,0 +1,112 @@
+# The configuration file for IMPSY: Interactive Musical Prediction System
+
+# Metadata about this configuration
+title = "X-TOUCH in Volca FM out"
+owner = "Charles Martin"
+description = "Uses x-touch over it's own USB connector and Volca FM over the Studio 1824c"
+
+# Basic config
+log_input = true
+log_predictions = false
+verbose = true
+
+# Interaction Configuration
+[interaction]
+mode = "callresponse" # Can be: "callresponse", "polyphony", "battle", "useronly"
+threshold = 0.1 # number of seconds before switching in call-response mode
+input_thru = true # sends inputs directly to outputs (e.g., if input interface is different than output synth)
+
+# Model configuration
+[model]
+dimension = 9
+file = "models/musicMDRNN-dim9-layers2-units64-mixtures5-scale10.h5" # default model, .tflite, .keras, .h5 options provided.
+size = "s" # Can be one of: xs, s, m, l, xl
+sigmatemp = 0.01
+pitemp = 1
+timescale = 1
+
+# MIDI Mapping
+[midi]
+in_device = ["X-TOUCH"]
+out_device = ["Studio 1824c"]
+input."X-TOUCH" = [ # XTOUCH-MINI knobs
+  ["control_change", 11, 1], # XTOUCH-MINI knob controller 1
+  ["control_change", 11, 2], # XTOUCH-MINI knob controller 2
+  ["control_change", 11, 3], # XTOUCH-MINI knob controller 3
+  ["control_change", 11, 4], # XTOUCH-MINI knob controller 4
+  ["control_change", 11, 5], # XTOUCH-MINI knob controller 5 
+  ["control_change", 11, 6], # XTOUCH-MINI knob controller 6
+  ["control_change", 11, 7], # XTOUCH-MINI knob controller 7
+  ["control_change", 11, 8], # XTOUCH-MINI knob controller 8
+]
+output."Studio 1824c" = [ # Volca FM
+  ["note_on", 1], # note
+  ["control_change", 1, 42], # Modulator Attack
+  ["control_change", 1, 43], # Modulator Decay
+  ["control_change", 1, 44], # Carrier Attack
+  ["control_change", 1, 45], # Carrier Decay
+  ["control_change", 1, 46], # LFO rate
+  ["control_change", 1, 47], # LFO depth
+  ["control_change", 1, 48], # Algorithm
+]
+
+[websocket]
+server_ip = "0.0.0.0" # The address of this server
+server_port = 5001 # The port this server should listen on.
+input = [ # Volca FM
+  ["note_on", 1], # note
+  ["control_change", 1, 42], # Modulator Attack
+  ["control_change", 1, 43], # Modulator Decay
+  ["control_change", 1, 44], # Carrier Attack
+  ["control_change", 1, 45], # Carrier Decay
+  ["control_change", 1, 46], # LFO rate
+  ["control_change", 1, 47], # LFO depth
+  ["control_change", 1, 48], # Algorithm
+]
+output = [ # Volca FM
+  ["note_on", 1], # note
+  ["control_change", 1, 42], # Modulator Attack
+  ["control_change", 1, 43], # Modulator Decay
+  ["control_change", 1, 44], # Carrier Attack
+  ["control_change", 1, 45], # Carrier Decay
+  ["control_change", 1, 46], # LFO rate
+  ["control_change", 1, 47], # LFO depth
+  ["control_change", 1, 48], # Algorithm
+]
+
+[osc]
+server_ip = "0.0.0.0" # Address of IMPSY
+server_port = 6000 # Port IMPSY listens on
+client_ip = "localhost" # Address of the output device
+client_port = 6001 # Port of the output device
+
+[serial]
+port = "/dev/ttyAMA0" # default GPIO serial port on raspberry pi
+baudrate = 115200 # a typical default choice of baudrate
+
+[serialmidi]
+port = "/dev/ttyAMA0" # default GPIO serial port on raspberry pi
+input = [ # Volca FM
+  ["note_on", 1], # note
+  ["control_change", 1, 42], # Modulator Attack
+  ["control_change", 1, 43], # Modulator Decay
+  ["control_change", 1, 44], # Carrier Attack
+  ["control_change", 1, 45], # Carrier Decay
+  ["control_change", 1, 46], # LFO rate
+  ["control_change", 1, 47], # LFO depth
+  ["control_change", 1, 48], # Algorithm
+]
+output = [ # Volca FM
+  ["note_on", 1], # note
+  ["control_change", 1, 42], # Modulator Attack
+  ["control_change", 1, 43], # Modulator Decay
+  ["control_change", 1, 44], # Carrier Attack
+  ["control_change", 1, 45], # Carrier Decay
+  ["control_change", 1, 46], # LFO rate
+  ["control_change", 1, 47], # LFO depth
+  ["control_change", 1, 48], # Algorithm
+]
+
+[webui]
+monitor_port = 4001  # Localhost port the webui's Realtime page listens on.
+command_port = 4002  # Localhost port IMPSY listens on for webui /commands.

--- a/impsy/web_interface.py
+++ b/impsy/web_interface.py
@@ -8,6 +8,7 @@ import os
 import time
 import tomllib
 from importlib.metadata import PackageNotFoundError, metadata as _pkg_metadata, version as _pkg_version
+from importlib.resources import files as _pkg_files
 from threading import Lock, Thread
 from impsy.dataset import generate_dataset
 from pathlib import Path
@@ -18,12 +19,65 @@ app = Flask(__name__)
 app.secret_key = "impsywebui"
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = Path(os.path.dirname(CURRENT_DIR))
-LOGS_DIR = PROJECT_ROOT / "logs"
-MODEL_DIR = PROJECT_ROOT / "models"
-DATASET_DIR = PROJECT_ROOT / "datasets"
-CONFIGS_DIR = PROJECT_ROOT / "configs"
-CONFIG_FILE = "config.toml"
+
+
+def _detect_workspace() -> Path:
+    """Detect the IMPSY workspace directory.
+
+    Precedence:
+    1. `IMPSY_WORKDIR` environment variable, if set.
+    2. The package's parent directory, if it contains `pyproject.toml`
+       (source-tree clone — preserves the dev experience).
+    3. The current working directory (pip-installed users).
+    """
+    env = os.environ.get("IMPSY_WORKDIR")
+    if env:
+        return Path(env).expanduser().resolve()
+    source_root = Path(CURRENT_DIR).resolve().parent
+    if (source_root / "pyproject.toml").exists():
+        return source_root
+    return Path.cwd().resolve()
+
+
+def _refresh_layout(root: Path) -> None:
+    """Recompute the workspace-relative path globals from `root`."""
+    global PROJECT_ROOT, LOGS_DIR, MODEL_DIR, DATASET_DIR, CONFIGS_DIR, CONFIG_FILE
+    PROJECT_ROOT = root
+    LOGS_DIR = root / "logs"
+    MODEL_DIR = root / "models"
+    DATASET_DIR = root / "datasets"
+    CONFIGS_DIR = root / "configs"
+    CONFIG_FILE = root / "config.toml"
+
+
+def set_workspace(path) -> None:
+    """Override the IMPSY workspace directory at runtime.
+
+    Used by `impsy webui --workdir` and may be useful for tests.
+    """
+    _refresh_layout(Path(path).expanduser().resolve())
+
+
+def _default_config_template() -> str | None:
+    """Return the bundled default config template as text, or None if missing."""
+    try:
+        return _pkg_files("impsy.data").joinpath("default.toml").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError):
+        return None
+
+
+def _create_default_config() -> bool:
+    """Write the bundled default template to CONFIG_FILE. Returns True on success."""
+    template = _default_config_template()
+    if template is None:
+        return False
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(template, encoding="utf-8")
+    return True
+
+
+_refresh_layout(_detect_workspace())
+
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 4000
 
@@ -505,9 +559,7 @@ def edit_config():
 @app.route("/config/create-default", methods=["POST"])
 def create_default_config():
     """Create config.toml from the default template."""
-    default_config = CONFIGS_DIR / "default.toml"
-    if default_config.exists():
-        shutil.copy2(default_config, CONFIG_FILE)
+    if _create_default_config():
         flash(
             "Created config.toml from default template. Edit it to match your setup.",
             "success",
@@ -695,15 +747,12 @@ def commands():
 
 def run_web_interface(host=DEFAULT_HOST, port=DEFAULT_PORT, debug=True):
     """Runs the Flask web interface."""
-    # Auto-create config.toml from default if it doesn't exist
-    if not os.path.exists(CONFIG_FILE):
-        default_config = CONFIGS_DIR / "default.toml"
-        if default_config.exists():
-            shutil.copy2(default_config, CONFIG_FILE)
-            click.secho(f"Created config.toml from default template", fg="green")
+    # Auto-create config.toml from the bundled default template if absent.
+    if not CONFIG_FILE.exists() and _create_default_config():
+        click.secho("Created config.toml from default template", fg="green")
 
+    click.secho(f"Workspace: {PROJECT_ROOT}", fg="blue")
     click.secho(f"Starting web interface at http://{host}:{port}", fg="blue")
-    click.secho(f"Log path: {LOGS_DIR}", fg="blue")
     app.run(host=host, port=port, debug=debug)
 
 
@@ -711,6 +760,16 @@ def run_web_interface(host=DEFAULT_HOST, port=DEFAULT_PORT, debug=True):
 @click.option("--host", default=DEFAULT_HOST, help="The host to bind to.")
 @click.option("--port", default=DEFAULT_PORT, help="The port to bind to.")
 @click.option("--debug", is_flag=True, help="Enable debug mode.")
-def webui(host, port, debug):
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="IMPSY workspace directory (where logs/, models/, datasets/, config.toml live). "
+    "Defaults to the source-tree root when running from a clone, otherwise the current directory.",
+)
+def webui(host, port, debug, workdir):
     """Run IMPSY Web UI giving access to files and other commands."""
+    if workdir is not None:
+        workdir.mkdir(parents=True, exist_ok=True)
+        set_workspace(workdir)
     run_web_interface(host, port, debug)

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -11,7 +11,11 @@ from impsy.web_interface import (
     allowed_dataset_file,
     get_version,
     get_software_info,
+    set_workspace,
+    _default_config_template,
+    _detect_workspace,
 )
+from impsy import web_interface as webui_mod
 
 
 @pytest.fixture
@@ -54,6 +58,62 @@ def test_get_version_independent_of_cwd(tmp_path, monkeypatch):
     assert get_version()  # still resolves from installed metadata
     info = get_software_info()
     assert info.get("Project") == "impsy"
+
+
+@pytest.fixture
+def restored_workspace():
+    """Restore the module-level workspace after a test mutates it."""
+    saved = webui_mod.PROJECT_ROOT
+    yield
+    set_workspace(saved)
+
+
+def test_default_config_template_is_packaged():
+    """The bundled default.toml must be readable via importlib.resources."""
+    template = _default_config_template()
+    assert template is not None
+    # Sanity: it should look like a TOML config with the expected top-level sections
+    assert "[interaction]" in template
+    assert "[model]" in template
+
+
+def test_set_workspace_relocates_all_paths(tmp_path, restored_workspace):
+    """set_workspace() must update every workspace-relative module global."""
+    set_workspace(tmp_path)
+    assert webui_mod.PROJECT_ROOT == tmp_path.resolve()
+    assert webui_mod.LOGS_DIR == tmp_path.resolve() / "logs"
+    assert webui_mod.MODEL_DIR == tmp_path.resolve() / "models"
+    assert webui_mod.DATASET_DIR == tmp_path.resolve() / "datasets"
+    assert webui_mod.CONFIG_FILE == tmp_path.resolve() / "config.toml"
+
+
+def test_detect_workspace_uses_env_var(tmp_path, monkeypatch):
+    """IMPSY_WORKDIR env var takes precedence over auto-detection."""
+    monkeypatch.setenv("IMPSY_WORKDIR", str(tmp_path))
+    assert _detect_workspace() == tmp_path.resolve()
+
+
+def test_detect_workspace_falls_back_to_cwd(tmp_path, monkeypatch):
+    """Without env var or source-tree pyproject.toml, workspace = CWD."""
+    monkeypatch.delenv("IMPSY_WORKDIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    # Move the package's source-tree pyproject.toml temporarily out of view by
+    # pointing the detector at a fake CURRENT_DIR whose parent has no pyproject.
+    fake_pkg = tmp_path / "fake_site_packages" / "impsy"
+    fake_pkg.mkdir(parents=True)
+    monkeypatch.setattr(webui_mod, "CURRENT_DIR", str(fake_pkg))
+    assert _detect_workspace() == tmp_path.resolve()
+
+
+def test_create_default_config_writes_template(tmp_path, restored_workspace):
+    """_create_default_config writes the bundled template into CONFIG_FILE."""
+    set_workspace(tmp_path)
+    assert not webui_mod.CONFIG_FILE.exists()
+    assert webui_mod._create_default_config() is True
+    assert webui_mod.CONFIG_FILE.exists()
+    content = webui_mod.CONFIG_FILE.read_text()
+    assert "[interaction]" in content
+    assert "[model]" in content
 
 
 def test_logs_route(client):


### PR DESCRIPTION
## Summary

- Replaces the source-tree-relative `PROJECT_ROOT = Path(__file__).parent.parent` derivation in `impsy/web_interface.py` with a layered workspace resolver:
  1. `--workdir <dir>` on `impsy webui` (also `IMPSY_WORKDIR` env var)
  2. Source-tree root if the package has a sibling `pyproject.toml`
  3. Otherwise `Path.cwd()`
  Previously, pip-installed users had `LOGS_DIR`/`MODEL_DIR`/`DATASET_DIR` pointing into `site-packages` — uploads silently went to the wrong place.
- `set_workspace()` is exposed for the CLI and for tests; it refreshes the module-level path globals (`PROJECT_ROOT`, `LOGS_DIR`, `MODEL_DIR`, `DATASET_DIR`, `CONFIGS_DIR`, `CONFIG_FILE`) so existing imports keep working.
- Bundles a default config template as `impsy/data/default.toml` (verified shipping inside the wheel via `poetry build`) and reads it through `importlib.resources`. Replaces the broken `CONFIGS_DIR / "default.toml"` lookup in `create_default_config` (POST) and `run_web_interface` (first-run auto-create).
- Five new tests cover: template packaging, workspace switching, env-var override, CWD fallback for installed-package layout, and the bundled config write.

Closes #81. Part of the broader pip-install workflow effort (#80 already landed; #82 init scaffolding and #83 README quickstart still open).

## Test plan

- [x] `poetry run pytest` — 149 passed locally (144 + 5 new)
- [x] `poetry run impsy webui --help` shows the new `--workdir` flag
- [x] `poetry build` — `impsy/data/default.toml` is in the wheel
- [x] `IMPSY_WORKDIR=/tmp/foo poetry run python -c "from impsy.web_interface import CONFIG_FILE; print(CONFIG_FILE)"` → `/tmp/foo/config.toml`
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)