### PR TITLE
Add impsy init command to scaffold a workspace

### DIFF
--- a/impsy/data/__init__.py
+++ b/impsy/data/__init__.py
@@ -1,0 +1,15 @@
+"""Bundled data resources shipped inside the impsy wheel.
+
+Currently holds the default config template used by `impsy init` and the
+webui's first-run auto-create path.
+"""
+
+from importlib.resources import files
+
+
+def default_config_template() -> str | None:
+    """Return the bundled default.toml template as text, or None if missing."""
+    try:
+        return files(__name__).joinpath("default.toml").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None

--- a/impsy/impsy.py
+++ b/impsy/impsy.py
@@ -2,6 +2,7 @@
 
 import click
 from .dataset import dataset
+from .init import init
 from .train import train
 from .interaction import run
 from .tflite_converter import convert_tflite
@@ -14,6 +15,7 @@ def cli():
     pass
 
 
+cli.add_command(init)
 cli.add_command(dataset)
 cli.add_command(train)
 cli.add_command(run)

--- a/impsy/init.py
+++ b/impsy/init.py
@@ -1,0 +1,107 @@
+"""Workspace scaffolding command: `impsy init`."""
+
+from pathlib import Path
+
+import click
+
+from impsy.data import default_config_template
+
+WORKSPACE_DIRS = ("logs", "datasets", "models")
+
+
+def scaffold_workspace(target: Path, force: bool = False) -> dict:
+    """Create the IMPSY workspace layout under `target`.
+
+    Returns a dict with keys:
+      - created_dirs: list[Path] of directories that were created
+      - existing_dirs: list[Path] of directories that already existed
+      - config_file: Path to config.toml in the target
+      - config_action: 'created' | 'overwritten' | 'kept' | 'no-template'
+    """
+    target = target.expanduser().resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    created_dirs = []
+    existing_dirs = []
+    for name in WORKSPACE_DIRS:
+        d = target / name
+        if d.exists():
+            existing_dirs.append(d)
+        else:
+            d.mkdir(parents=True)
+            created_dirs.append(d)
+
+    config_file = target / "config.toml"
+    template = default_config_template()
+    if template is None:
+        config_action = "no-template"
+    elif config_file.exists() and not force:
+        config_action = "kept"
+    else:
+        action = "overwritten" if config_file.exists() else "created"
+        config_file.write_text(template, encoding="utf-8")
+        config_action = action
+
+    return {
+        "target": target,
+        "created_dirs": created_dirs,
+        "existing_dirs": existing_dirs,
+        "config_file": config_file,
+        "config_action": config_action,
+    }
+
+
+@click.command(name="init")
+@click.argument(
+    "directory",
+    required=False,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite an existing config.toml. Existing logs/, datasets/, models/ "
+    "directories are always left in place regardless of this flag.",
+)
+def init(directory, force):
+    """Scaffold an IMPSY workspace (logs/, datasets/, models/, config.toml).
+
+    Without a positional argument, initialises the current directory. The
+    bundled default config template is copied to config.toml unless one
+    already exists (use --force to overwrite).
+    """
+    target = directory if directory is not None else Path.cwd()
+    result = scaffold_workspace(target, force=force)
+
+    click.secho(f"Workspace: {result['target']}", fg="blue")
+    for d in result["created_dirs"]:
+        click.secho(f"  created   {d.name}/", fg="green")
+    for d in result["existing_dirs"]:
+        click.secho(f"  exists    {d.name}/", fg="yellow")
+
+    action = result["config_action"]
+    cfg = result["config_file"]
+    if action == "created":
+        click.secho(f"  created   {cfg.name}", fg="green")
+    elif action == "overwritten":
+        click.secho(f"  overwrote {cfg.name}", fg="green")
+    elif action == "kept":
+        click.secho(
+            f"  exists    {cfg.name} (use --force to overwrite)", fg="yellow"
+        )
+    else:  # no-template
+        click.secho(
+            "  warning   bundled default template not found; "
+            "config.toml not written",
+            fg="red",
+        )
+
+    click.secho("", fg="blue")
+    click.secho("Next steps:", fg="blue")
+    click.secho(f"  1. Edit {cfg} to match your I/O setup", fg="blue")
+    click.secho("  2. `impsy run` to start logging interactions", fg="blue")
+    click.secho(
+        "  3. `impsy dataset` then `impsy train` once you have logs to train on",
+        fg="blue",
+    )

--- a/impsy/web_interface.py
+++ b/impsy/web_interface.py
@@ -8,8 +8,8 @@ import os
 import time
 import tomllib
 from importlib.metadata import PackageNotFoundError, metadata as _pkg_metadata, version as _pkg_version
-from importlib.resources import files as _pkg_files
 from threading import Lock, Thread
+from impsy.data import default_config_template
 from impsy.dataset import generate_dataset
 from pathlib import Path
 from pythonosc import dispatcher, osc_server
@@ -58,17 +58,13 @@ def set_workspace(path) -> None:
     _refresh_layout(Path(path).expanduser().resolve())
 
 
-def _default_config_template() -> str | None:
-    """Return the bundled default config template as text, or None if missing."""
-    try:
-        return _pkg_files("impsy.data").joinpath("default.toml").read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError):
-        return None
+# Backwards-compatible alias kept for tests that imported this earlier.
+_default_config_template = default_config_template
 
 
 def _create_default_config() -> bool:
     """Write the bundled default template to CONFIG_FILE. Returns True on success."""
-    template = _default_config_template()
+    template = default_config_template()
     if template is None:
         return False
     CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,97 @@
+"""Tests for the `impsy init` scaffolding command."""
+
+from click.testing import CliRunner
+
+from impsy import init as init_module
+from impsy.impsy import cli
+
+
+def test_scaffold_creates_dirs_and_config(tmp_path):
+    result = init_module.scaffold_workspace(tmp_path)
+    assert result["target"] == tmp_path.resolve()
+    assert result["config_action"] == "created"
+    for name in ("logs", "datasets", "models"):
+        assert (tmp_path / name).is_dir()
+        assert (tmp_path / name) in result["created_dirs"]
+    assert result["config_file"] == tmp_path / "config.toml"
+    assert (tmp_path / "config.toml").exists()
+    content = (tmp_path / "config.toml").read_text()
+    assert "[interaction]" in content
+    assert "[model]" in content
+
+
+def test_scaffold_keeps_existing_config(tmp_path):
+    """Second invocation without --force must leave config.toml alone."""
+    (tmp_path / "config.toml").write_text('title = "user edits"\n')
+    result = init_module.scaffold_workspace(tmp_path)
+    assert result["config_action"] == "kept"
+    assert (tmp_path / "config.toml").read_text() == 'title = "user edits"\n'
+
+
+def test_scaffold_force_overwrites_config(tmp_path):
+    (tmp_path / "config.toml").write_text('title = "stale"\n')
+    result = init_module.scaffold_workspace(tmp_path, force=True)
+    assert result["config_action"] == "overwritten"
+    new_content = (tmp_path / "config.toml").read_text()
+    assert "[interaction]" in new_content
+    assert "stale" not in new_content
+
+
+def test_scaffold_idempotent_directories(tmp_path):
+    """Pre-existing logs/ etc. are reported as existing, not re-created."""
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / "old.log").write_text("keep me\n")
+    result = init_module.scaffold_workspace(tmp_path)
+    assert (tmp_path / "logs") in result["existing_dirs"]
+    assert (tmp_path / "logs") not in result["created_dirs"]
+    # Existing contents must be preserved.
+    assert (tmp_path / "logs" / "old.log").read_text() == "keep me\n"
+
+
+def test_init_cli_default_target_is_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "logs").is_dir()
+    assert (tmp_path / "config.toml").exists()
+    assert "Next steps" in result.output
+
+
+def test_init_cli_with_positional_directory(tmp_path):
+    """Positional DIRECTORY arg targets that path, not CWD."""
+    target = tmp_path / "my-workspace"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", str(target)])
+    assert result.exit_code == 0, result.output
+    assert target.is_dir()
+    assert (target / "logs").is_dir()
+    assert (target / "config.toml").exists()
+
+
+def test_init_cli_refuses_to_clobber_without_force(tmp_path):
+    (tmp_path / "config.toml").write_text('title = "mine"\n')
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "use --force" in result.output
+    assert (tmp_path / "config.toml").read_text() == 'title = "mine"\n'
+
+
+def test_init_cli_force_overwrites(tmp_path):
+    (tmp_path / "config.toml").write_text('title = "stale"\n')
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", str(tmp_path), "--force"])
+    assert result.exit_code == 0
+    content = (tmp_path / "config.toml").read_text()
+    assert "[interaction]" in content
+    assert "stale" not in content
+
+
+def test_init_cli_registered_in_group():
+    """`impsy init --help` must work via the top-level cli group."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--help"])
+    assert result.exit_code == 0
+    assert "Scaffold an IMPSY workspace" in result.output
+    assert "--force" in result.output


### PR DESCRIPTION
## Summary

- Adds `impsy init [DIRECTORY]` — creates `logs/`, `datasets/`, `models/` and writes the bundled default config template to `config.toml`. Default target is the current directory.
- `--force` overwrites an existing `config.toml`. Existing `logs/` / `datasets/` / `models/` and their contents are always preserved regardless of `--force`.
- Output is a one-line `created` / `exists` / `overwrote` summary per item plus a 3-step "next steps" footer so a first-time pip user knows what to do next.
- Refactor: the bundled-template lookup that `web_interface.py` did inline now lives in `impsy.data.default_config_template()`, shared between the new init command and the webui's first-run auto-create path.

Closes #82. Builds on #80 (console_scripts) and #85/#81 (bundled template + workspace paths) — together these get a fresh pip user from `pip install impsy` to a usable workspace in two commands.

## End-to-end smoke

\`\`\`
$ mkdir my-impsy && cd my-impsy && impsy init
Workspace: /tmp/my-impsy
  created   logs/
  created   datasets/
  created   models/
  created   config.toml

Next steps:
  1. Edit /tmp/my-impsy/config.toml to match your I/O setup
  2. \`impsy run\` to start logging interactions
  3. \`impsy dataset\` then \`impsy train\` once you have logs to train on
\`\`\`

Re-running without `--force` reports `exists  config.toml (use --force to overwrite)` and leaves user edits intact.

## Test plan

- [x] `poetry run pytest` — 158 passed locally (149 + 9 new)
- [x] `poetry run impsy init --help` and `poetry run impsy --help` show the new subcommand
- [x] Manual smoke: scaffold → re-run preserves edits → `--force` overwrites
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)